### PR TITLE
Add code copy button

### DIFF
--- a/app.R
+++ b/app.R
@@ -36,7 +36,7 @@ ui <- list(
       tags$li(class = "dropdown", actionLink("info", icon("info"))),
       tags$li(
         class = "dropdown",
-        boastUtils::surveyLink(name = "Hasse_Diagrams") 
+        boastUtils::surveyLink(name = "Hasse_Diagrams")
       ),
       tags$li(class = "dropdown",
               tags$a(href = 'https://shinyapps.science.psu.edu/',
@@ -100,7 +100,7 @@ ui <- list(
             br(),
             br(),
             br(),
-            div(class = "updated", "Last Update: 2/16/2023 by NJH.")
+            div(class = "updated", "Last Update: 2/27/2024 by NJH.")
           )
         ),
         #### Example Page ----
@@ -1746,7 +1746,8 @@ server <- function(input, output, session) {
       collapse = ", "
       )
       genCode <- paste0(
-        'modelLabels <- c(', labs, ')
+        'library(hasseDiagram)
+modelLabels <- c(', labs, ')
 modelMatrix <- matrix(
   data = c(', mat, '),
   nrow = ', length(hasseList$labels), ',
@@ -1758,11 +1759,11 @@ hasseDiagram::hasse(
  labels = modelLabels
 )'
       )
-      
+
       output$wizRCode <- renderText({
         genCode
       })
-      
+
       #### Clipboard ----
       output$clipboard <- renderUI({
         rclipButton(

--- a/app.R
+++ b/app.R
@@ -100,7 +100,7 @@ ui <- list(
             br(),
             br(),
             br(),
-            div(class = "updated", "Last Update: 9/23/2022 by NJH.")
+            div(class = "updated", "Last Update: 2/16/2023 by NJH.")
           )
         ),
         #### Example Page ----

--- a/app.R
+++ b/app.R
@@ -650,17 +650,18 @@ ui <- list(
                 code to paste into a code chunk or your console to create your
                 Hasse diagram."),
               fluidRow(
+                class = "d-flex",
                 column(
                   width = 8,
                   verbatimTextOutput("wizRCode")
                 ),
                 column(
+                  class = "d-flex",
                   width = 4,
-                  br(),
-                  br(),
-                  br(),
-                  br(),
-                  uiOutput("clipboard")
+                  div(
+                    class = "align-self-center",
+                    uiOutput("clipboard")
+                  )
                 )
               ),
               p(tags$em("Note: "), "you'll need to first have the appropriate

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,7 @@
 # Hasse Diagrams
 
-![experimental](https://img.shields.io/badge/lifecycle-experimental-orange)
+![maturing](https://img.shields.io/badge/lifecycle-maturing-blue)
 ![year](https://img.shields.io/badge/year-2021-lightgrey)
-![new](https://img.shields.io/badge/lifecycle-newapp-brightgreen)
 
 ![App Screenshot](https://sites.psu.edu/shinyapps/files/2021/02/Hasse-diag-e1613361066676-1536x768.png)
 


### PR DESCRIPTION
Adds a button that allows users to quickly copy the generated code for the hasse diagram
Resolves #6 